### PR TITLE
feat: Implement Responsive 404 Page Layout

### DIFF
--- a/src/layouts/ErrorLayout.astro
+++ b/src/layouts/ErrorLayout.astro
@@ -1,0 +1,35 @@
+---
+// 404 Error Page Layout
+import "../styles/global.css";
+const { title = "Oops! Page Not Found | Lupus Together" } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+
+    <!-- Brand FavIcon: Cross Browser Compatible -->
+    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+
+    <!-- Google Fonts: Quicksand + Playfair -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Quicksand:wght@300..700&display=swap"
+      rel="stylesheet"
+    />
+    <title>{title}</title>
+  </head>
+  <body>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,20 +1,86 @@
 ---
-// Outline of custom 404.astro page.
+// custom 404.astro page.
+import ErrorLayout from "../layouts/ErrorLayout.astro";
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Oops! Page Not Found | Lupus Together</title>
-  </head>
-  <body>
-    <main>
-      <h1>404</h1>
-      <h2>Page Not Found</h2>
+<ErrorLayout>
+  <style>
+    section {
+      width: 100%;
+      min-height: 100dvh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      background-color: var(--background-color);
+      padding: 0 1.5rem;
+    }
+    h1 {
+      font-size: clamp(3.5rem, 6vw, 12rem);
+      color: var(--primary-color);
+      font-family: var(--primary-font-family);
+      font-weight: 800;
+      margin-bottom: 0.5rem;
+    }
 
-      <a href="/" class="home-link">Go to Homepage</a>
-    </main>
-  </body>
-</html>
+    h2 {
+      font-size: clamp(1.2rem, 4vw, 2rem);
+      color: var(--primary-color);
+      margin-bottom: 1rem;
+      font-family: var(--primary-font-family);
+      margin-bottom: 1rem;
+    }
+
+    p {
+      font-family: var(--secondary-font-family);
+      font-size: clamp(0.9rem, 1.8vw, 1.1rem);
+      color: var(--text-color);
+      max-width: 600px;
+      line-height: 1.6;
+      letter-spacing: 0.08rem;
+      margin-bottom: 1.2rem;
+    }
+
+    .nav-btn {
+      display: inline-block;
+      margin-top: 0.5rem;
+      padding: 0.875rem 1.25rem;
+      font-size: clamp(0.9rem, 0.6vw + 0.5rem, 1rem);
+      background-color: var(--secondary-color);
+      font-family: var(--primary-font-family);
+      color: #ffffff;
+      border: none;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: bold;
+      cursor: pointer;
+      transition:
+        background-color 300ms ease,
+        transform 300ms ease;
+    }
+
+    .nav-btn:hover {
+      background-color: var(--btn-hover-color);
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+      transform: scale(1.02);
+    }
+  </style>
+  <section>
+    <h1>404</h1>
+    <h2>Page Not Found</h2>
+    <p>
+      Oops! It seems you've wandered off the path! The page you're looking for
+      doesn't exist or has been moved.
+    </p>
+    <p>
+      Don't worry, let's get you back on track to exploring the <span
+        style={{
+          color: "var(--primary-color)",
+          fontFamily: "var(--primary-font-family)",
+          fontWeight: "bold",
+        }}>Lupus Together community.</span
+      >
+    </p>
+    <a href="/" class="nav-btn">Go to Homepage</a>
+  </section>
+</ErrorLayout>


### PR DESCRIPTION
1. Styled custom 404 layout with responsive typography and branding stylings.

<img width="300" height="500" alt="Custom 404 page_2025-07-31 at 22-59-23 Oops! Page Not Found Lupus Together" src="https://github.com/user-attachments/assets/a24ba991-b1ac-454c-bd33-1c0305fd1146" />

Closes: #34 