### PR TITLE
fix: Removing redundant words from image alt attributes

### DIFF
--- a/src/components/Stories.astro
+++ b/src/components/Stories.astro
@@ -80,7 +80,7 @@ try {
                 {testimonial.avatar && testimonial.avatar.url && (
                   <img
                     src={`${STRAPI_URL_IMAGES}${testimonial.avatar.url}`}
-                    alt={`Profile Image of ${testimonial.name}`}
+                    alt={testimonial.name}
                   />
                 )}
                 <div class="avatar-title">


### PR DESCRIPTION
- Removing redundant words from image alt attributes (Testimonials section)
Closes: #48 